### PR TITLE
GH-NA: Update GitHub Actions

### DIFF
--- a/.github/workflows/check-labels.yaml
+++ b/.github/workflows/check-labels.yaml
@@ -1,0 +1,22 @@
+name: Check labels
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    name: DO-NOT-MERGE / unresolved review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 0
+          labels: "DO-NOT-MERGE, awaiting changes, awaiting change review"


### PR DESCRIPTION
Actions now run on the `ubuntu-latest` image rather than `self-hosted`. 

Label checker has been implemented preventing the merge of a PR if it has certain labels.