### PR TITLE
GH-24: Implement Alliance Managment Frame

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -52,9 +52,20 @@ class API:
         return player
 
     def get_alliance(self) -> Alliance | None:
-        route = Route("/alliance", "GET")
-        response = self.request(route)
-        data = response.json()
+        # route = Route("/alliance", "GET")      API BROKEN
+        # response = self.request(route)
+        # data = response.json()
+
+        # TEMPORARY CODE START
+        data = {
+            "owner": 796483244052447242,
+            "created_at": "2019-08-24T14:15:22",
+            "name": "remeber this is placeholder info",
+            "user_limit": 10,
+            "bank": 100000000,
+        }
+        # TEMPORARY CODE END
+
         alliance = Alliance.from_data(data)
         return alliance
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -52,19 +52,9 @@ class API:
         return player
 
     def get_alliance(self) -> Alliance | None:
-        # route = Route("/alliance", "GET")      API BROKEN
-        # response = self.request(route)
-        # data = response.json()
-
-        # TEMPORARY CODE START
-        data = {
-            "owner": 796483244052447242,
-            "created_at": "2019-08-24T14:15:22",
-            "name": "remeber this is placeholder info",
-            "user_limit": 10,
-            "bank": 100000000,
-        }
-        # TEMPORARY CODE END
+        route = Route("/alliance", "GET")
+        response = self.request(route)
+        data = response.json()
 
         alliance = Alliance.from_data(data)
         return alliance

--- a/gui/app.py
+++ b/gui/app.py
@@ -19,9 +19,6 @@ class App(tkinter.Tk):
         self.geometry("800x600")
         self.resizable(False, False)
 
-        # init sidebar
-        self.sidebar = Sidebar(self)
-
         self.api_key = self.verify_api()
         if not self.api_key:
             self.api_key_frame = APIKeyFrame(self)
@@ -29,11 +26,12 @@ class App(tkinter.Tk):
             self.current_frame.place(x=0, y=0, height=600, width=800)
             self.current_frame.render()
         else:
-            self.sidebar.place(x=0, y=0, height=600, width=150)
-            self.current_frame = LookupFrame(self)
-            self.build_main_frame()
+            self.build_app()
 
-        # init frames
+    def build_app(self, destroy: bool = False) -> None:
+        if destroy:
+            self.current_frame.place_forget()
+        self.sidebar = Sidebar(self)
         self.attack_frame = AttackFrame(self)
         self.lookup_frame = LookupFrame(self)
         self.npc_frame = NpcFrame(self)
@@ -42,12 +40,8 @@ class App(tkinter.Tk):
         self.alliance_frame = AllianceFrame(self)
         self.settings_frame = SettingsFrame(self)
         self.api_key_frame = APIKeyFrame(self)
-
-    def build_main_frame(self):
-        if self.current_frame:
-            self.current_frame.place_forget()
         self.sidebar.place(x=0, y=0, height=600, width=150)
-        self.current_frame = LookupFrame(self)
+        self.current_frame = self.lookup_frame
         self.current_frame.place(x=150, y=0, height=600, width=650)
         self.current_frame.render()
 

--- a/gui/app.py
+++ b/gui/app.py
@@ -19,15 +19,8 @@ class App(tkinter.Tk):
         self.geometry("800x600")
         self.resizable(False, False)
 
+        # init sidebar
         self.sidebar = Sidebar(self)
-        self.attack_frame = AttackFrame(self)
-        self.lookup_frame = LookupFrame(self)
-        self.npc_frame = NpcFrame(self)
-        self.recruitment_frame = RecruitmentFrame(self)
-        self.construction_frame = ConstructionFrame(self)
-        self.alliance_frame = AllianceFrame(self)
-        self.settings_frame = SettingsFrame(self)
-        self.api_key_frame = APIKeyFrame(self)
 
         self.api_key = self.verify_api()
         if not self.api_key:
@@ -37,14 +30,24 @@ class App(tkinter.Tk):
             self.current_frame.render()
         else:
             self.sidebar.place(x=0, y=0, height=600, width=150)
-            self.current_frame = self.lookup_frame
+            self.current_frame = LookupFrame(self)
             self.build_main_frame()
+
+        # init frames
+        self.attack_frame = AttackFrame(self)
+        self.lookup_frame = LookupFrame(self)
+        self.npc_frame = NpcFrame(self)
+        self.recruitment_frame = RecruitmentFrame(self)
+        self.construction_frame = ConstructionFrame(self)
+        self.alliance_frame = AllianceFrame(self)
+        self.settings_frame = SettingsFrame(self)
+        self.api_key_frame = APIKeyFrame(self)
 
     def build_main_frame(self):
         if self.current_frame:
             self.current_frame.place_forget()
         self.sidebar.place(x=0, y=0, height=600, width=150)
-        self.current_frame = self.lookup_frame
+        self.current_frame = LookupFrame(self)
         self.current_frame.place(x=150, y=0, height=600, width=650)
         self.current_frame.render()
 

--- a/gui/app.py
+++ b/gui/app.py
@@ -7,6 +7,7 @@ from gui.frames.lookup import LookupFrame
 from gui.frames.npc import NpcFrame
 from gui.frames.recruitment import RecruitmentFrame
 from gui.frames.construction import ConstructionFrame
+from gui.frames.alliance import AllianceFrame
 from gui.frames.settings import SettingsFrame
 from gui.frames.api_key import APIKeyFrame
 
@@ -24,6 +25,7 @@ class App(tkinter.Tk):
         self.npc_frame = NpcFrame(self)
         self.recruitment_frame = RecruitmentFrame(self)
         self.construction_frame = ConstructionFrame(self)
+        self.alliance_frame = AllianceFrame(self)
         self.settings_frame = SettingsFrame(self)
         self.api_key_frame = APIKeyFrame(self)
 

--- a/gui/components/inputs.py
+++ b/gui/components/inputs.py
@@ -18,7 +18,7 @@ class IntergerOnlyEntry(tkinter.Entry):
 
         self.var = tkinter.StringVar()
 
-        super().__init__(parent, textvariable=self.var, *args, **kwargs)
+        super().__init__(parent, width=50, textvariable=self.var, *args, **kwargs)
 
         self.validate_command = (self.register(self.validate_input), "%P")
 

--- a/gui/components/labels.py
+++ b/gui/components/labels.py
@@ -20,8 +20,8 @@ class FrameLabel(tkinter.Label):
 
 
 class InputLabel(tkinter.Label):
-    def __init__(self, parent, text):
-        super().__init__(parent, text=text, bg="#ffffff")
+    def __init__(self, parent, text, bg="#ffffff"):
+        super().__init__(parent, text=text, bg=bg)
 
 
 class PopUpLabel(tkinter.Label):

--- a/gui/frames/alliance.py
+++ b/gui/frames/alliance.py
@@ -1,6 +1,8 @@
+# pyright: reportOptionalMemberAccess=false
+# TODO for neil fix later
+
 import tkinter
 from ..components import labels, inputs, buttons
-from backend.api import API
 
 
 class AllianceFrame(tkinter.Frame):
@@ -8,7 +10,7 @@ class AllianceFrame(tkinter.Frame):
         super().__init__(parent, width=650, height=600, bg="orange")
         self.parent = parent
 
-        self.allianceData = self.get_alliance_data()
+        self.allianceData = self.parent.backend.get_alliance()
 
         self.label = labels.FrameLabel(self, text="Alliance")
 
@@ -50,31 +52,17 @@ class AllianceFrame(tkinter.Frame):
             command=self.update_alliance_user_limit,
         )
 
-    def get_alliance_data(self):
-        with open("API_KEY.txt", "r") as f:
-            apiKey = f.read()
-
-        backend = API(apiKey)
-
-        return backend.get_alliance()
-
     def update_alliance_name(self):
         name = self.allianceNameUpdateField.get()
-        with open("API_KEY.txt", "r") as f:
-            apiKey = f.read()
 
-        backend = API(apiKey)
-        backend.update_alliance_name(name)
+        self.parent.backend.update_alliance_name(name)
 
         self.parent.change_frame(self)  # reload frame
 
     def update_alliance_user_limit(self):
         user_limit = self.allianceUserLimitUpdateField.get()
-        with open("API_KEY.txt", "r") as f:
-            apiKey = f.read()
 
-        backend = API(apiKey)
-        backend.update_alliance_user_limit(user_limit)
+        self.parent.backend.update_alliance_user_limit(int(user_limit))
 
         self.parent.change_frame(self)  # reload frame
 

--- a/gui/frames/alliance.py
+++ b/gui/frames/alliance.py
@@ -1,0 +1,99 @@
+import tkinter
+from ..components import labels, inputs, buttons
+from backend.api import API
+
+
+class AllianceFrame(tkinter.Frame):
+    def __init__(self, parent):
+        super().__init__(parent, width=650, height=600, bg="orange")
+        self.parent = parent
+
+        self.allianceData = self.get_alliance_data()
+
+        self.label = labels.FrameLabel(self, text="Alliance")
+
+        # alliance info
+        self.allianceNameLabel = labels.InputLabel(
+            self, f"Alliance: {self.allianceData.name}"
+        )
+        self.allianceOwnerLabel = labels.InputLabel(
+            self, f"Owner (Discord ID): {self.allianceData.owner}"
+        )
+        self.allianceUserLimitLabel = labels.InputLabel(
+            self, f'User Limit: {"{:,}".format(self.allianceData.user_limit)}'
+        )  # includes formating number with commas
+        self.allianceBankBalanceLabel = labels.InputLabel(
+            self, f'Bank Balance: {"{:,}".format(self.allianceData.bank)}'
+        )  # includes formating number with commas
+        self.allianceCreationTimestamp = labels.InputLabel(
+            self, f"Alliance Creation Timestamp: {self.allianceData.created_at}"
+        )
+
+        # update section
+        self.allianceUpdateLabel = labels.InputLabel(self, "Update Alliance Info")
+
+        self.allianceNameUpdateLabel = labels.InputLabel(self, "Update Name:")
+        self.allianceNameUpdateField = inputs.TextInput(self)
+        self.allianceNameUpdateSubmit = buttons.SubmitButton(
+            self, text="Submit", width=10, height=1, command=self.update_alliance_name
+        )
+
+        self.allianceUserLimitUpdateLabel = labels.InputLabel(
+            self, "Update User Limit:"
+        )
+        self.allianceUserLimitUpdateField = inputs.IntergerOnlyEntry(self)
+        self.allianceUserLimitUpdateSubmit = buttons.SubmitButton(
+            self,
+            text="Submit",
+            width=10,
+            height=1,
+            command=self.update_alliance_user_limit,
+        )
+
+    def get_alliance_data(self):
+        with open("API_KEY.txt", "r") as f:
+            apiKey = f.read()
+
+        backend = API(apiKey)
+
+        return backend.get_alliance()
+
+    def update_alliance_name(self):
+        name = self.allianceNameUpdateField.get()
+        with open("API_KEY.txt", "r") as f:
+            apiKey = f.read()
+
+        backend = API(apiKey)
+        backend.update_alliance_name(name)
+
+        self.parent.change_frame(self)  # reload frame
+
+    def update_alliance_user_limit(self):
+        user_limit = self.allianceUserLimitUpdateField.get()
+        with open("API_KEY.txt", "r") as f:
+            apiKey = f.read()
+
+        backend = API(apiKey)
+        backend.update_alliance_user_limit(user_limit)
+
+        self.parent.change_frame(self)  # reload frame
+
+    def render(self):
+        self.label.grid(row=0, column=0)
+
+        # render alliance info
+        self.allianceNameLabel.place(x=245, y=100)
+        self.allianceOwnerLabel.place(x=245, y=125)
+        self.allianceUserLimitLabel.place(x=310, y=150)
+        self.allianceBankBalanceLabel.place(x=280, y=175)
+
+        # render alliance updating
+        self.allianceUpdateLabel.place(x=295, y=225)
+
+        self.allianceNameUpdateLabel.place(x=100, y=250)
+        self.allianceNameUpdateField.place(x=190, y=250)
+        self.allianceNameUpdateSubmit.place(x=500, y=247)
+
+        self.allianceUserLimitUpdateLabel.place(x=80, y=275)
+        self.allianceUserLimitUpdateField.place(x=190, y=275)
+        self.allianceUserLimitUpdateSubmit.place(x=500, y=272)

--- a/gui/frames/alliance.py
+++ b/gui/frames/alliance.py
@@ -57,14 +57,18 @@ class AllianceFrame(tkinter.Frame):
 
         self.parent.backend.update_alliance_name(name)
 
-        self.parent.change_frame(self)  # reload frame
+        self.parent.change_frame(
+            AllianceFrame(self.parent)
+        )  # TODO instead of initialising a new frame, update the current frame
 
     def update_alliance_user_limit(self):
         user_limit = self.allianceUserLimitUpdateField.get()
 
         self.parent.backend.update_alliance_user_limit(int(user_limit))
 
-        self.parent.change_frame(self)  # reload frame
+        self.parent.change_frame(
+            AllianceFrame(self.parent)
+        )  # TODO instead of initialising a new frame, update the current frame
 
     def render(self):
         self.label.grid(row=0, column=0)

--- a/gui/frames/api_key.py
+++ b/gui/frames/api_key.py
@@ -24,7 +24,7 @@ class APIKeyFrame(tkinter.Frame):
             with open("API_KEY.txt", "w") as f:
                 f.write(self.apikeyentry.get())
             self.parent.backend = backend
-            self.parent.build_main_frame()
+            self.parent.build_app()
         else:
             self.apikeyentry.delete(0, "end")
             self.apikeyentry.insert(0, "Invalid API Key")

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -36,6 +36,13 @@ class Sidebar(tkinter.Frame):
         )
         self.recruitment_button.pack()
 
+        self.alliance_button = buttons.Sidebarbutton(
+            self,
+            text="Alliance",
+            command=lambda: self.switch_frame(self.parent.alliance_frame),
+        )
+        self.alliance_button.pack()
+
         self.lookup_button = buttons.Sidebarbutton(
             self,
             text="Lookup",


### PR DESCRIPTION
Note: In this PR, response from the get_alliance API method is hard-coded, as the methods are currently broken. @ItsNeil17 said to leave testing to him, once the API methods are fixed. The update part is entirely untested. PR also includes changes to frame initialization, moving it to after the API key is verified. This is to allow for use of the API in the `__init__ ` functions of frames.

<!-- gh-issue-number: gh-24 -->
* Issue: gh-24
<!-- /gh-issue-number -->
